### PR TITLE
Add conditional fields to add-client page

### DIFF
--- a/assets/js/admin-custom-tables.js
+++ b/assets/js/admin-custom-tables.js
@@ -8,6 +8,34 @@ jQuery(document).ready(function($) {
     const sellerForm = $('#jtsm-seller-form');
     const submitContainer = $('#jtsm-submit-button-container');
 
+    // --- Add Client Form Logic ---
+    const userTypeField = $('#jtsm_user_type');
+    const serviceField = $('#product_service').closest('div');
+    const panelKwField = $('#product_kw').closest('div');
+    const proposalField = $('#proposal_amount').closest('div');
+
+    function toggleClientFields(userType) {
+        if (userType === 'seller') {
+            serviceField.hide();
+            panelKwField.hide();
+            proposalField.hide();
+            $('#product_service').prop('required', false);
+        } else {
+            serviceField.show();
+            panelKwField.show();
+            proposalField.show();
+            $('#product_service').prop('required', true);
+        }
+    }
+
+    // Initialize client fields based on current selection
+    if (userTypeField.length) {
+        toggleClientFields(userTypeField.val());
+        userTypeField.on('change', function () {
+            toggleClientFields($(this).val());
+        });
+    }
+
     // Function to show/hide payment forms based on client type
     function togglePaymentForms(clientType) {
         // Hide all forms and the submit button first


### PR DESCRIPTION
## Summary
- adjust JavaScript used in admin to hide client product fields when the user type is seller

## Testing
- `php -l justech-solar-management.php`
- `php -l includes/jtsm-crud.php`
- `php -l includes/jtsm-list-view.php`
- `php -l includes/view-client-detail.php`
- `php -l includes/jtsm-setup.php`


------
https://chatgpt.com/codex/tasks/task_e_68836c9e038c8324aa8e890143d81a25