### PR TITLE
Add conditional fields to add-client page

### DIFF
--- a/assets/js/admin-custom-tables.js
+++ b/assets/js/admin-custom-tables.js
@@ -8,6 +8,34 @@ jQuery(document).ready(function($) {
     const sellerForm = $('#jtsm-seller-form');
     const submitContainer = $('#jtsm-submit-button-container');
 
+    // --- Add Client Form Logic ---
+    const userTypeField = $('#jtsm_user_type');
+    const serviceField = $('#product_service').closest('div');
+    const panelKwField = $('#product_kw').closest('div');
+    const proposalField = $('#proposal_amount').closest('div');
+
+    function toggleClientFields(userType) {
+        if (userType === 'seller') {
+            serviceField.hide();
+            panelKwField.hide();
+            proposalField.hide();
+            $('#product_service').prop('required', false);
+        } else {
+            serviceField.show();
+            panelKwField.show();
+            proposalField.show();
+            $('#product_service').prop('required', true);
+        }
+    }
+
+    // Initialize client fields based on current selection
+    if (userTypeField.length) {
+        toggleClientFields(userTypeField.val());
+        userTypeField.on('change', function () {
+            toggleClientFields($(this).val());
+        });
+    }
+
     // Function to show/hide payment forms based on client type
     function togglePaymentForms(clientType) {
         // Hide all forms and the submit button first

--- a/includes/jtsm-setup.php
+++ b/includes/jtsm-setup.php
@@ -78,6 +78,8 @@ final class JTSM_Solar_Management_Setup {
             user_type varchar(20) DEFAULT 'consumer' NOT NULL,
             gstin varchar(15),
             product_service text,
+            product_kw varchar(50),
+            proposal_amount decimal(10,2),
             file_url varchar(255),
             status varchar(20) DEFAULT 'pending' NOT NULL,
             created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,

--- a/includes/view-client-detail.php
+++ b/includes/view-client-detail.php
@@ -69,6 +69,24 @@ function jtsm_render_view_client_page() {
                         <p class="font-medium text-gray-500">Address</p>
                         <p class="text-gray-900"><?php echo nl2br(esc_html($client->address)) ?: 'N/A'; ?></p>
                     </div>
+                    <?php if ($client->product_service): ?>
+                    <div>
+                        <p class="font-medium text-gray-500">Service Name</p>
+                        <p class="text-gray-900"><?php echo esc_html($client->product_service); ?></p>
+                    </div>
+                    <?php endif; ?>
+                    <?php if ($client->product_kw): ?>
+                    <div>
+                        <p class="font-medium text-gray-500">Panel K/W</p>
+                        <p class="text-gray-900"><?php echo esc_html($client->product_kw); ?></p>
+                    </div>
+                    <?php endif; ?>
+                    <?php if ($client->proposal_amount): ?>
+                    <div>
+                        <p class="font-medium text-gray-500">Proposal Amount</p>
+                        <p class="text-gray-900"><?php echo number_format(floatval($client->proposal_amount), 2); ?></p>
+                    </div>
+                    <?php endif; ?>
                      <?php if ($client->file_url): ?>
                     <div class="sm:col-span-2">
                          <p class="font-medium text-gray-500">Uploaded File</p>

--- a/justech-solar-management.php
+++ b/justech-solar-management.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Justech Solar Management (Custom Tables)
  * Plugin URI:        https://example.com/
  * Description:       A plugin to manage solar clients and payments using custom database tables and Tailwind CSS.
- * Version:           2.4.0
+ * Version:           2.5.0
  * Author:            Your Name
  * Author URI:        https://example.com/
  * License:           GPL v2 or later
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Define constants for the plugin.
  */
-define( 'JTSM_VERSION', '2.4.0' );
+define( 'JTSM_VERSION', '2.5.0' );
 define( 'JTSM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JTSM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
## Summary
- adjust JavaScript used in admin to hide client product fields when the user type is seller
- add product_kw and proposal_amount columns
- show product information on the view client page
- bump version to 2.5.0

## Testing
- `php -l justech-solar-management.php`
- `php -l includes/jtsm-crud.php`
- `php -l includes/jtsm-list-view.php`
- `php -l includes/view-client-detail.php`
- `php -l includes/jtsm-setup.php`


------
https://chatgpt.com/codex/tasks/task_e_68836c9e038c8324aa8e890143d81a25