### PR TITLE
Add new expanse user type and payments

### DIFF
--- a/assets/js/admin-custom-tables.js
+++ b/assets/js/admin-custom-tables.js
@@ -6,6 +6,7 @@ jQuery(document).ready(function($) {
     const clientSelector = $('#jtsm_client_id');
     const consumerForm = $('#jtsm-consumer-form');
     const sellerForm = $('#jtsm-seller-form');
+    const expanseForm = $('#jtsm-expanse-form');
     const submitContainer = $('#jtsm-submit-button-container');
 
     // --- Add Client Form Logic ---
@@ -13,17 +14,30 @@ jQuery(document).ready(function($) {
     const serviceField = $('#product_service').closest('div');
     const panelKwField = $('#product_kw').closest('div');
     const proposalField = $('#proposal_amount').closest('div');
+    const companyField = $('#jtsm_company_name').closest('div');
+    const shortDescField = $('#jtsm_short_description').closest('div');
 
     function toggleClientFields(userType) {
         if (userType === 'seller') {
             serviceField.hide();
             panelKwField.hide();
             proposalField.hide();
+            companyField.show();
+            shortDescField.hide();
+            $('#product_service').prop('required', false);
+        } else if (userType === 'expanse') {
+            serviceField.hide();
+            panelKwField.hide();
+            proposalField.hide();
+            companyField.hide();
+            shortDescField.show();
             $('#product_service').prop('required', false);
         } else {
             serviceField.show();
             panelKwField.show();
             proposalField.show();
+            companyField.show();
+            shortDescField.hide();
             $('#product_service').prop('required', true);
         }
     }
@@ -41,6 +55,7 @@ jQuery(document).ready(function($) {
         // Hide all forms and the submit button first
         consumerForm.hide();
         sellerForm.hide();
+        expanseForm.hide();
         submitContainer.hide();
 
         if (clientType === 'consumer') {
@@ -48,6 +63,9 @@ jQuery(document).ready(function($) {
             submitContainer.show();
         } else if (clientType === 'seller') {
             sellerForm.show();
+            submitContainer.show();
+        } else if (clientType === 'expanse') {
+            expanseForm.show();
             submitContainer.show();
         }
     }

--- a/includes/jtsm-crud.php
+++ b/includes/jtsm-crud.php
@@ -31,7 +31,7 @@ class JTSM_Solar_Management_CRUD {
                     <?php wp_nonce_field( 'jtsm_add_client_action', 'jtsm_add_client_nonce' ); ?>
                     <div class="grid grid-cols-6 md:grid-cols-6 gap-6">
 
-                    <div class="md:col-span-2"><label for="jtsm_user_type" class="block text-sm font-medium text-gray-700">Type of User</label><select name="jtsm_user_type" id="jtsm_user_type" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"><option value="consumer">Consumer</option><option value="seller">Seller</option></select></div>
+                    <div class="md:col-span-2"><label for="jtsm_user_type" class="block text-sm font-medium text-gray-700">Type of User</label><select name="jtsm_user_type" id="jtsm_user_type" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"><option value="consumer">Consumer</option><option value="seller">Seller</option><option value="expanse">Expanse</option></select></div>
 
                     <div class="md:col-span-4"><label for="jtsm_company_name" class="jtsm-seller block text-sm font-medium text-gray-700">Company Name</label><input type="text" name="jtsm_company_name" id="jtsm_company_name" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"></div>
 
@@ -45,6 +45,8 @@ class JTSM_Solar_Management_CRUD {
 
 
                         <div class="md:col-span-3"><label for="jtsm_contact_number" class="block text-sm font-medium text-gray-700">Contact Number</label><input type="text" name="jtsm_contact_number" id="jtsm_contact_number" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"></div>
+
+                        <div class="md:col-span-3 jtsm-expanse"><label for="jtsm_short_description" class="block text-sm font-medium text-gray-700">Short Description</label><textarea name="jtsm_short_description" id="jtsm_short_description" class="h-24 mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"></textarea></div>
 
 
                         <div class="md:col-span-2">
@@ -91,6 +93,7 @@ class JTSM_Solar_Management_CRUD {
             'last_name' => sanitize_text_field($_POST['jtsm_last_name']),
             'company_name' => sanitize_text_field($_POST['jtsm_company_name']),
             'contact_number' => sanitize_text_field($_POST['jtsm_contact_number']),
+            'short_description' => sanitize_textarea_field($_POST['jtsm_short_description']),
             'product_service' => sanitize_text_field($_POST['product_service']),
             'product_kw' => sanitize_text_field($_POST['product_kw']),
             'proposal_amount' => floatval($_POST['proposal_amount']),
@@ -158,6 +161,7 @@ class JTSM_Solar_Management_CRUD {
                             <select name="jtsm_user_type" id="jtsm_user_type" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                                 <option value="consumer" <?php selected( $client->user_type, 'consumer' ); ?>>Consumer</option>
                                 <option value="seller" <?php selected( $client->user_type, 'seller' ); ?>>Seller</option>
+                                <option value="expanse" <?php selected( $client->user_type, 'expanse' ); ?>>Expanse</option>
                             </select>
                         </div>
 
@@ -184,6 +188,11 @@ class JTSM_Solar_Management_CRUD {
                         <div class="md:col-span-3">
                             <label for="jtsm_contact_number" class="block text-sm font-medium text-gray-700">Contact Number</label>
                             <input type="text" name="jtsm_contact_number" id="jtsm_contact_number" value="<?php echo esc_attr( $client->contact_number ); ?>" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                        </div>
+
+                        <div class="md:col-span-3 jtsm-expanse">
+                            <label for="jtsm_short_description" class="block text-sm font-medium text-gray-700">Short Description</label>
+                            <textarea name="jtsm_short_description" id="jtsm_short_description" class="h-24 mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"><?php echo esc_textarea( $client->short_description ); ?></textarea>
                         </div>
 
                         <div class="md:col-span-2">
@@ -235,6 +244,7 @@ class JTSM_Solar_Management_CRUD {
             'last_name'       => sanitize_text_field( $_POST['jtsm_last_name'] ),
             'company_name'    => sanitize_text_field( $_POST['jtsm_company_name'] ),
             'contact_number'  => sanitize_text_field( $_POST['jtsm_contact_number'] ),
+            'short_description' => sanitize_textarea_field( $_POST['jtsm_short_description'] ),
             'product_service' => sanitize_text_field( $_POST['product_service'] ),
             'product_kw'      => sanitize_text_field( $_POST['product_kw'] ),
             'proposal_amount' => floatval( $_POST['proposal_amount'] ),
@@ -317,6 +327,15 @@ class JTSM_Solar_Management_CRUD {
                         <div><label for="jtsm_payment_date_seller" class="block text-sm font-medium text-gray-700">Payment Date</label><input type="date" name="jtsm_payment_date_seller" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"></div>
                     </div>
 
+                    <div id="jtsm-expanse-form" class="hidden space-y-4">
+                        <h2 class="text-lg font-medium text-gray-900 border-b pb-2">Expanse Payment</h2>
+                        <div><label for="jtsm_expanse_service" class="block text-sm font-medium text-gray-700">Service</label><input type="text" name="jtsm_expanse_service" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"></div>
+                        <div><label for="jtsm_expanse_amount" class="block text-sm font-medium text-gray-700">Amount</label><input type="number" step="0.01" name="jtsm_expanse_amount" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"></div>
+                        <div><label for="jtsm_payment_mode_expanse" class="block text-sm font-medium text-gray-700">Payment Mode</label><select name="jtsm_payment_mode_expanse" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"><option value="upi">UPI</option><option value="cash">Cash</option><option value="netbanking">Net Banking</option><option value="other">Other</option></select></div>
+                        <div><label for="jtsm_payment_type_expanse" class="block text-sm font-medium text-gray-700">Payment Type</label><select name="jtsm_payment_type_expanse" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"><option value="receiver">Receiver</option><option value="sender">Sender</option></select></div>
+                        <div><label for="jtsm_payment_date_expanse" class="block text-sm font-medium text-gray-700">Payment Date</label><input type="date" name="jtsm_payment_date_expanse" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"></div>
+                    </div>
+
                     <div id="jtsm-submit-button-container" class="mt-6 hidden">
                         <?php submit_button('Add Payment', 'primary', 'submit', true, ['class' => 'inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500']); ?>
                     </div>
@@ -350,11 +369,7 @@ class JTSM_Solar_Management_CRUD {
             $data['payment_mode'] = sanitize_text_field($_POST['jtsm_payment_mode_consumer']);
             $data['payment_receive'] = sanitize_text_field($_POST['jtsm_payment_receive_consumer']);
             $data['payment_date'] = sanitize_text_field($_POST['jtsm_payment_date_consumer']);
-
-
-            
-            $data['payment_date'] = sanitize_text_field($_POST['jtsm_payment_date_consumer']);
-        } else { // Seller
+        } elseif ($client->user_type === 'seller') {
             $data['amount_without_gst'] = floatval($_POST['jtsm_amount_without_gst']);
             $data['gst_rate'] = intval($_POST['jtsm_gst_rate']);
             $data['amount_with_gst'] = floatval($_POST['jtsm_amount_with_gst']);
@@ -371,6 +386,12 @@ class JTSM_Solar_Management_CRUD {
                     $data['invoice_url'] = $movefile['url'];
                 }
             }
+        } else { // Expanse
+            $data['expense_service'] = sanitize_text_field($_POST['jtsm_expanse_service']);
+            $data['amount'] = floatval($_POST['jtsm_expanse_amount']);
+            $data['payment_mode'] = sanitize_text_field($_POST['jtsm_payment_mode_expanse']);
+            $data['payment_type'] = sanitize_text_field($_POST['jtsm_payment_type_expanse']);
+            $data['payment_date'] = sanitize_text_field($_POST['jtsm_payment_date_expanse']);
         }
 
         $result = $wpdb->insert($table_name, $data);

--- a/includes/jtsm-setup.php
+++ b/includes/jtsm-setup.php
@@ -71,6 +71,7 @@ final class JTSM_Solar_Management_Setup {
             company_name tinytext,
             contact_number varchar(20) DEFAULT '' NOT NULL,
             email varchar(100) DEFAULT '' NOT NULL,
+            short_description text,
             address text,
             city tinytext,
             state tinytext,
@@ -99,6 +100,8 @@ final class JTSM_Solar_Management_Setup {
             payment_receive varchar(100),
             payment_date date,
             invoice_url varchar(255),
+            expense_service text,
+            payment_type varchar(20),
             created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
             PRIMARY KEY  (id)
         ) $charset_collate;";


### PR DESCRIPTION
## Summary
- support a new **expanse** user type
- include short description for clients
- handle expanse payments with receiver/sender types
- extend admin JS to toggle new fields
- update list views and table setup for the new data

## Testing
- `php -l includes/jtsm-crud.php`
- `php -l includes/jtsm-list-view.php`
- `php -l includes/jtsm-setup.php`
- `php -l justech-solar-management.php`
- `node -e "require('fs').readFileSync('assets/js/admin-custom-tables.js');" >/dev/null && echo 'JS ok'`

------
https://chatgpt.com/codex/tasks/task_e_68837a12794483248429cf62e69933f9