### PR TITLE
Improve payment sender form

### DIFF
--- a/assets/js/admin-custom-tables.js
+++ b/assets/js/admin-custom-tables.js
@@ -8,6 +8,8 @@ jQuery(document).ready(function($) {
     const sellerForm = $('#jtsm-seller-form');
     const expanseForm = $('#jtsm-expanse-form');
     const submitContainer = $('#jtsm-submit-button-container');
+    const paymentTypeField = $('#jtsm_payment_type_expanse');
+    const otherClientContainer = $('#jtsm-other-client-container');
 
     // --- Add Client Form Logic ---
     const userTypeField = $('#jtsm_user_type');
@@ -128,5 +130,20 @@ jQuery(document).ready(function($) {
     // Add event listeners to calculate GST automatically
     amountWithoutGstField.on('input', calculateGst);
     gstRateField.on('change', calculateGst);
+
+    function toggleOtherClientField(val) {
+        if (val === 'sender') {
+            otherClientContainer.show();
+        } else {
+            otherClientContainer.hide();
+        }
+    }
+
+    if (paymentTypeField.length) {
+        toggleOtherClientField(paymentTypeField.val());
+        paymentTypeField.on('change', function () {
+            toggleOtherClientField($(this).val());
+        });
+    }
 
 });

--- a/includes/jtsm-list-view.php
+++ b/includes/jtsm-list-view.php
@@ -120,7 +120,12 @@ class JTSM_Solar_Management_List_View {
         $payments_table = $wpdb->prefix . 'jtsm_payments';
 
 
-        $sql = "SELECT p.*, c.first_name, c.last_name, c.user_type FROM $payments_table p LEFT JOIN $clients_table c ON p.client_id = c.id";
+        $sql = "SELECT p.*, c.first_name, c.last_name, c.user_type,
+                       oc.first_name AS other_first_name,
+                       oc.last_name AS other_last_name
+                FROM $payments_table p
+                LEFT JOIN $clients_table c ON p.client_id = c.id
+                LEFT JOIN $clients_table oc ON p.other_client_id = oc.id";
 
         // Add a WHERE clause if a filter is selected
         if ($filter === 'consumer' || $filter === 'seller' || $filter === 'expender') {
@@ -281,7 +286,11 @@ class JTSM_Solar_Management_List_View {
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                                 <?php
                                     if ($payment->user_type === 'expender') {
-                                        echo ucfirst(esc_html($payment->payment_type));
+                                        $label = ucfirst(esc_html($payment->payment_type));
+                                        if ($payment->payment_type === 'sender' && $payment->other_first_name) {
+                                            $label .= ' to ' . esc_html($payment->other_first_name . ' ' . $payment->other_last_name);
+                                        }
+                                        echo $label;
                                     } else {
                                         echo ucfirst(esc_html($payment->payment_receive));
                                     }

--- a/includes/jtsm-setup.php
+++ b/includes/jtsm-setup.php
@@ -102,6 +102,7 @@ final class JTSM_Solar_Management_Setup {
             invoice_url varchar(255),
             expense_service text,
             payment_type varchar(20),
+            other_client_id mediumint(9),
             created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
             PRIMARY KEY  (id)
         ) $charset_collate;";


### PR DESCRIPTION
## Summary
- order clients as expender, consumer then seller on the add payment page
- allow selecting another client when payment type is sender
- store the other client id in payments table
- show recipient on payment list
- toggle recipient field with JavaScript

## Testing
- `php -l includes/jtsm-crud.php`
- `php -l includes/jtsm-setup.php`
- `php -l includes/jtsm-list-view.php`
- `php -l assets/js/admin-custom-tables.js`

------
https://chatgpt.com/codex/tasks/task_e_68838643a9648324a912ea0fc547abb2