### PR TITLE
Enable editing existing payments

### DIFF
--- a/includes/jtsm-list-view.php
+++ b/includes/jtsm-list-view.php
@@ -318,7 +318,9 @@ class JTSM_Solar_Management_List_View {
                                 ?>
                             </td>
 
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium"><a href="#" class="text-indigo-600 hover:text-indigo-900">Edit</a> | <a href="#" class="text-red-600 hover:text-red-900">Delete</a></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                <a href="<?php echo esc_url( admin_url( 'admin.php?page=jtsm-edit-payment&payment_id=' . $payment->id ) ); ?>" class="text-indigo-600 hover:text-indigo-900">Edit</a> | <a href="#" class="text-red-600 hover:text-red-900">Delete</a>
+                            </td>
                         </tr>
                     <?php endforeach; else: ?>
                         <tr><td colspan="6" class="text-center py-4">No payments found for this filter.</td></tr>

--- a/includes/jtsm-setup.php
+++ b/includes/jtsm-setup.php
@@ -121,11 +121,11 @@ final class JTSM_Solar_Management_Setup {
        add_submenu_page('jtsm-main-menu', 'Add New Client', 'Add New Client', 'manage_options', 'jtsm-add-client',   [JTSM_Solar_Management_CRUD::instance(),'jtsm_render_add_client_page' ]);
        add_submenu_page('jtsm-main-menu', 'All Payments', 'All Payments', 'manage_options', 'jtsm-all-payments',  [JTSM_Solar_Management_List_View::instance(),'jtsm_render_payment_list_page' ]);
        add_submenu_page('jtsm-main-menu', 'Add New Payment', 'Add New Payment', 'manage_options', 'jtsm-add-payment',  [JTSM_Solar_Management_CRUD::instance(),'jtsm_render_add_payment_page' ]);
-   
-   
+
+
        add_submenu_page(null, 'View Client', 'View Client', 'manage_options', 'jtsm-view-client', 'jtsm_render_view_client_page');
        add_submenu_page(null, 'Edit Client', 'Edit Client', 'manage_options', 'jtsm-edit-client', [ JTSM_Solar_Management_CRUD::instance(), 'jtsm_render_edit_client_page' ]);
-     //  add_submenu_page(null, 'Edit Payment', 'Edit Payment', 'manage_options', 'jtsm-edit-payment', [ $this, 'jtsm_render_edit_payment_page' ]);
+       add_submenu_page(null, 'Edit Payment', 'Edit Payment', 'manage_options', 'jtsm-edit-payment', [ JTSM_Solar_Management_CRUD::instance(), 'jtsm_render_edit_payment_page' ]);
    
    
     }

--- a/includes/view-client-detail.php
+++ b/includes/view-client-detail.php
@@ -146,8 +146,8 @@ function jtsm_render_view_client_page() {
                         <?php endif; ?>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Mode</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Receive</th>
-
                         <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
                 <tbody class="bg-white divide-y divide-gray-200">
@@ -169,20 +169,22 @@ function jtsm_render_view_client_page() {
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo ucfirst(esc_html($payment->payment_mode)); ?></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo ucfirst(esc_html($payment->payment_receive)); ?></td>
-
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
-                                <?php 
+                                <?php
                                     echo number_format(floatval($payment->amount), 2);
                                 ?>
                             </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                <a href="<?php echo esc_url( admin_url( 'admin.php?page=jtsm-edit-payment&payment_id=' . $payment->id ) ); ?>" class="text-indigo-600 hover:text-indigo-900">Edit</a>
+                            </td>
                         </tr>
                     <?php endforeach; else: ?>
-                        <tr><td colspan="4" class="text-center py-10 text-gray-500">No payments have been recorded for this client.</td></tr>
+                        <tr><td colspan="6" class="text-center py-10 text-gray-500">No payments have been recorded for this client.</td></tr>
                     <?php endif; ?>
                 </tbody>
                  <tfoot class="bg-gray-50">
                     <tr>
-                        <td colspan="4" class="px-6 py-3 text-right text-sm font-bold text-zinc-950 uppercase">Total</td>
+                        <td colspan="5" class="px-6 py-3 text-right text-sm font-bold text-zinc-950 uppercase">Total</td>
                         <td class="px-6 py-3 text-right text-sm font-bold text-zinc-950"><?php echo number_format($total_paid, 2); ?></td>
                     </tr>
                 </tfoot>


### PR DESCRIPTION
## Summary
- add hidden submenu for editing payments and link from lists
- implement payment edit form with update logic for all client types
- expose edit links in payment listings and client detail view

## Testing
- `php -l includes/jtsm-crud.php`
- `php -l includes/jtsm-list-view.php`
- `php -l includes/jtsm-setup.php`
- `php -l includes/view-client-detail.php`


------
https://chatgpt.com/codex/tasks/task_e_68a30c96f5f483248a7ddba631cf25b8