### PR TITLE
Add AJAX search for clients and payments

### DIFF
--- a/assets/js/admin-custom-tables.js
+++ b/assets/js/admin-custom-tables.js
@@ -150,4 +150,44 @@ jQuery(document).ready(function($) {
         });
     }
 
+    // --- AJAX Search for Clients ---
+    const clientSearch = $('#jtsm-client-search');
+    clientSearch.on('input', function () {
+        $.ajax({
+            url: jtsm_ajax_object.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'jtsm_search_clients',
+                _ajax_nonce: jtsm_ajax_object.nonce,
+                term: $(this).val(),
+                filter: $('#filter').val()
+            },
+            success: function (response) {
+                if (response.success) {
+                    $('#jtsm-client-table-body').html(response.data.html);
+                }
+            }
+        });
+    });
+
+    // --- AJAX Search for Payments ---
+    const paymentSearch = $('#jtsm-payment-search');
+    paymentSearch.on('input', function () {
+        $.ajax({
+            url: jtsm_ajax_object.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'jtsm_search_payments',
+                _ajax_nonce: jtsm_ajax_object.nonce,
+                term: $(this).val(),
+                filter: $('#filter').val()
+            },
+            success: function (response) {
+                if (response.success) {
+                    $('#jtsm-payment-table-body').html(response.data.html);
+                }
+            }
+        });
+    });
+
 });

--- a/includes/jtsm-setup.php
+++ b/includes/jtsm-setup.php
@@ -14,7 +14,7 @@ final class JTSM_Solar_Management_Setup {
 
     private function __construct() {
 
-
+        JTSM_Solar_Management_List_View::instance();
 
 
         add_action( 'admin_menu', [ $this, 'jtsm_admin_menu' ] );


### PR DESCRIPTION
## Summary
- add AJAX-powered search to client and payment list pages
- expose backend search handlers for clients and payments
- wire up admin JS to update tables dynamically

## Testing
- `php -l includes/jtsm-list-view.php`
- `php -l includes/jtsm-setup.php`
- `node --check assets/js/admin-custom-tables.js`


------
https://chatgpt.com/codex/tasks/task_e_68a31983e1888324b5a0aefc84e5840d