### PR TITLE
Add AJAX search for clients and payments

### DIFF
--- a/assets/js/jtsm-search.js
+++ b/assets/js/jtsm-search.js
@@ -1,0 +1,53 @@
+jQuery(document).ready(function($) {
+    'use strict';
+
+    var clientSearch = $('#jtsm-client-search');
+    var paymentSearch = $('#jtsm-payment-search');
+
+    function searchClients() {
+        var query = clientSearch.val();
+        var filter = $('#filter').val();
+        $.ajax({
+            url: jtsm_ajax_object.ajax_url,
+            method: 'POST',
+            data: {
+                action: 'jtsm_search_clients',
+                _ajax_nonce: jtsm_ajax_object.nonce,
+                search: query,
+                filter: filter
+            },
+            success: function(response) {
+                if (response.success) {
+                    $('#jtsm-clients-table-body').html(response.data.html);
+                }
+            }
+        });
+    }
+
+    function searchPayments() {
+        var query = paymentSearch.val();
+        var filter = $('#filter').val();
+        $.ajax({
+            url: jtsm_ajax_object.ajax_url,
+            method: 'POST',
+            data: {
+                action: 'jtsm_search_payments',
+                _ajax_nonce: jtsm_ajax_object.nonce,
+                search: query,
+                filter: filter
+            },
+            success: function(response) {
+                if (response.success) {
+                    $('#jtsm-payments-table-body').html(response.data.html);
+                }
+            }
+        });
+    }
+
+    if (clientSearch.length) {
+        clientSearch.on('keyup', searchClients);
+    }
+    if (paymentSearch.length) {
+        paymentSearch.on('keyup', searchPayments);
+    }
+});

--- a/includes/jtsm-list-view.php
+++ b/includes/jtsm-list-view.php
@@ -64,8 +64,8 @@ class JTSM_Solar_Management_List_View {
                 <a href="?page=jtsm-add-client" class="jstm-text-color inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700">Add New Client</a>
             </div>
             
-            <!-- Filter Row -->
-            <div class="mb-4">
+            <!-- Filter and Search Row -->
+            <div class="mb-4 flex items-center space-x-4">
                 <form method="get" class="inline-block bg-white p-4 rounded-lg shadow-md">
                     <input type="hidden" name="page" value="jtsm-main-menu">
                     <label for="filter" class="text-sm font-medium text-gray-700 mr-2">Filter by Type:</label>
@@ -76,6 +76,7 @@ class JTSM_Solar_Management_List_View {
                         <option value="expender" <?php selected($filter, 'expender'); ?>>Expender</option>
                     </select>
                 </form>
+                <input type="text" id="jtsm-client-search" placeholder="Search..." class="bg-white p-2 rounded-lg shadow-md border border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" />
             </div>
 
             <div class="bg-white shadow-md rounded-lg overflow-hidden">
@@ -92,7 +93,7 @@ class JTSM_Solar_Management_List_View {
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
                         </tr>
                     </thead>
-                    <tbody class="bg-white divide-y divide-gray-200">
+                    <tbody class="bg-white divide-y divide-gray-200" id="jtsm-clients-table-body">
                     <?php if ($clients): foreach ($clients as $client): ?>
                         <?php
                             $view_link = admin_url('admin.php?page=jtsm-view-client&client_id=' . $client->id);
@@ -206,6 +207,10 @@ class JTSM_Solar_Management_List_View {
                 <a href="?page=jtsm-add-payment" class="jstm-text-color inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:border-indigo-900 focus:ring ring-indigo-300 disabled:opacity-25 transition ease-in-out duration-150">Add New Payment</a>
             </div>
 
+            <div class="mb-4">
+                <input type="text" id="jtsm-payment-search" placeholder="Search..." class="w-full md:w-1/3 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" />
+            </div>
+
             <!-- Filter and Total Amount Row -->
             <div class="grid grid-cols-1 <?php echo $filter === 'all' ? 'md:grid-cols-4' : 'md:grid-cols-2'; ?> gap-4 mb-4">
                 <!-- Filter Form -->
@@ -279,7 +284,7 @@ class JTSM_Solar_Management_List_View {
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Receive/Type</th>
 
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th></tr></thead>
-                    <tbody class="bg-white divide-y divide-gray-200">
+                    <tbody class="bg-white divide-y divide-gray-200" id="jtsm-payments-table-body">
                     <?php if ($payments): foreach ($payments as $payment): ?>
                         <tr>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><?php echo esc_html($payment->first_name . ' ' . $payment->last_name); ?></td>
@@ -329,5 +334,137 @@ class JTSM_Solar_Management_List_View {
             </div>
         </div>
         <?php
+    }
+
+    /**
+     * AJAX search handler for clients list.
+     */
+    public function jtsm_ajax_search_clients() {
+        check_ajax_referer('jtsm_ajax_nonce');
+        global $wpdb;
+        $clients_table  = $wpdb->prefix . 'jtsm_clients';
+        $filter = isset($_POST['filter']) ? sanitize_text_field($_POST['filter']) : 'all';
+        $search = isset($_POST['search']) ? sanitize_text_field($_POST['search']) : '';
+
+        $sql = "SELECT * FROM $clients_table";
+        $where = [];
+        if ( $filter === 'consumer' || $filter === 'seller' || $filter === 'expender' ) {
+            $where[] = $wpdb->prepare("user_type = %s", $filter);
+        }
+        if ( $search !== '' ) {
+            $like = '%' . $wpdb->esc_like( $search ) . '%';
+            $where[] = $wpdb->prepare("(first_name LIKE %s OR last_name LIKE %s OR company_name LIKE %s)", $like, $like, $like);
+        }
+        if ( $where ) {
+            $sql .= ' WHERE ' . implode(' AND ', $where);
+        }
+        $sql .= ' ORDER BY created_at DESC';
+        $clients = $wpdb->get_results( $sql );
+
+        ob_start();
+        if ( $clients ) {
+            foreach ( $clients as $client ) {
+                $view_link   = admin_url( 'admin.php?page=jtsm-view-client&client_id=' . $client->id );
+                $edit_link   = admin_url( 'admin.php?page=jtsm-edit-client&client_id=' . $client->id );
+                $delete_link = wp_nonce_url( admin_url( 'admin.php?page=jtsm-main-menu&action=delete_client&client_id=' . $client->id ), 'jtsm_delete_client_' . $client->id );
+                ?>
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><a href="<?php echo esc_url( $view_link ); ?>" class="text-indigo-600 hover:text-indigo-900"><?php echo esc_html( $client->first_name . ' ' . $client->last_name ); ?></a></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo esc_html( $client->company_name ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo esc_html( $client->contact_number ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <?php
+                        $badge = 'bg-blue-100 text-blue-800';
+                        if ( $client->user_type === 'consumer' ) {
+                            $badge = 'bg-green-100 text-green-800';
+                        } elseif ( $client->user_type === 'seller' ) {
+                            $badge = 'bg-pink-100 text-pink-800';
+                        }
+                        ?>
+                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full <?php echo $badge; ?>"><?php echo ucfirst( esc_html( $client->user_type ) ); ?></span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo number_format( floatval( $client->proposal_amount ), 2 ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo $this->total_payment_clients( $clients_table, $client->id ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $client->created_at ) ) ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium"><a href="<?php echo esc_url( $view_link ); ?>" class="text-gray-600 hover:text-indigo-900">View</a> | <a href="<?php echo esc_url( $edit_link ); ?>" class="text-indigo-600 hover:text-indigo-900">Edit</a> | <a href="<?php echo esc_url( $delete_link ); ?>" class="text-red-600 hover:text-red-900" onclick="return confirm('Are you sure you want to delete this client and all their payments?');">Delete</a></td>
+                </tr>
+                <?php
+            }
+        } else {
+            echo '<tr><td colspan="8" class="text-center py-4">No clients found.</td></tr>';
+        }
+        $html = ob_get_clean();
+        wp_send_json_success( [ 'html' => $html ] );
+    }
+
+    /**
+     * AJAX search handler for payments list.
+     */
+    public function jtsm_ajax_search_payments() {
+        check_ajax_referer('jtsm_ajax_nonce');
+        global $wpdb;
+        $clients_table = $wpdb->prefix . 'jtsm_clients';
+        $payments_table = $wpdb->prefix . 'jtsm_payments';
+        $filter = isset($_POST['filter']) ? sanitize_text_field($_POST['filter']) : 'all';
+        $search = isset($_POST['search']) ? sanitize_text_field($_POST['search']) : '';
+
+        $sql = "SELECT p.*, c.first_name, c.last_name, c.user_type, oc.first_name AS other_first_name, oc.last_name AS other_last_name FROM $payments_table p LEFT JOIN $clients_table c ON p.client_id = c.id LEFT JOIN $clients_table oc ON p.other_client_id = oc.id";
+        $where = [];
+        if ( $filter === 'consumer' || $filter === 'seller' || $filter === 'expender' ) {
+            $where[] = $wpdb->prepare('c.user_type = %s', $filter);
+        }
+        if ( $search !== '' ) {
+            $like = '%' . $wpdb->esc_like( $search ) . '%';
+            $where[] = $wpdb->prepare('(c.first_name LIKE %s OR c.last_name LIKE %s)', $like, $like);
+        }
+        if ( $where ) {
+            $sql .= ' WHERE ' . implode(' AND ', $where);
+        }
+        $sql .= ' ORDER BY p.payment_date DESC';
+        $payments = $wpdb->get_results( $sql );
+
+        ob_start();
+        if ( $payments ) {
+            foreach ( $payments as $payment ) {
+                $edit_link = admin_url('admin.php?page=jtsm-edit-payment&payment_id=' . $payment->id);
+                ?>
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><?php echo esc_html( $payment->first_name . ' ' . $payment->last_name ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <?php
+                        $badge = 'bg-blue-100 text-blue-800';
+                        if ( $payment->user_type === 'consumer' ) {
+                            $badge = 'bg-green-100 text-green-800';
+                        } elseif ( $payment->user_type === 'seller' ) {
+                            $badge = 'bg-pink-100 text-pink-800';
+                        }
+                        ?>
+                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full <?php echo $badge; ?>"><?php echo ucfirst( esc_html( $payment->user_type ) ); ?></span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo esc_html( $payment->payment_date ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo number_format( floatval( $payment->amount ), 2 ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><?php echo ucfirst( esc_html( $payment->payment_mode ) ); ?></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <?php
+                        if ( $payment->user_type === 'expender' ) {
+                            $label = ucfirst( esc_html( $payment->payment_type ) );
+                            if ( $payment->payment_type === 'sender' && $payment->other_first_name ) {
+                                $label .= ' to ' . esc_html( $payment->other_first_name . ' ' . $payment->other_last_name );
+                            }
+                            echo $label;
+                        } else {
+                            echo ucfirst( esc_html( $payment->payment_receive ) );
+                        }
+                        ?>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium"><a href="<?php echo esc_url( $edit_link ); ?>" class="text-indigo-600 hover:text-indigo-900">Edit</a> | <a href="#" class="text-red-600 hover:text-red-900">Delete</a></td>
+                </tr>
+                <?php
+            }
+        } else {
+            echo '<tr><td colspan="6" class="text-center py-4">No payments found for this filter.</td></tr>';
+        }
+        $html = ob_get_clean();
+        wp_send_json_success( [ 'html' => $html ] );
     }
 }

--- a/includes/jtsm-setup.php
+++ b/includes/jtsm-setup.php
@@ -20,6 +20,8 @@ final class JTSM_Solar_Management_Setup {
         add_action( 'admin_menu', [ $this, 'jtsm_admin_menu' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'jtsm_enqueue_scripts' ] );
         add_action( 'wp_ajax_jtsm_get_client_type_table', [ $this, 'jtsm_get_client_type_ajax_handler' ] );
+        add_action( 'wp_ajax_jtsm_search_clients', [ JTSM_Solar_Management_List_View::instance(), 'jtsm_ajax_search_clients' ] );
+        add_action( 'wp_ajax_jtsm_search_payments', [ JTSM_Solar_Management_List_View::instance(), 'jtsm_ajax_search_payments' ] );
     }
 
     /**
@@ -35,10 +37,11 @@ final class JTSM_Solar_Management_Setup {
 
         // Enqueue Tailwind CSS
         wp_enqueue_script('tailwindcss', 'https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4', array('jquery'), JTSM_VERSION, true);
-        
+
         // Enqueue JS for dynamic forms
         wp_enqueue_script( 'jtsm-admin-js', JTSM_PLUGIN_URL . 'assets/js/admin-custom-tables.js', [ 'jquery' ], JTSM_VERSION, true );
         wp_localize_script( 'jtsm-admin-js', 'jtsm_ajax_object', [ 'ajax_url' => admin_url( 'admin-ajax.php' ), 'nonce' => wp_create_nonce('jtsm_ajax_nonce') ] );
+        wp_enqueue_script( 'jtsm-search-js', JTSM_PLUGIN_URL . 'assets/js/jtsm-search.js', [ 'jquery', 'jtsm-admin-js' ], JTSM_VERSION, true );
     }
 
     /**


### PR DESCRIPTION
## Summary
- add search fields and AJAX handlers to filter client list dynamically
- enable AJAX search in payments list with new JavaScript and backend callbacks

## Testing
- `php -l includes/jtsm-setup.php`
- `php -l includes/jtsm-list-view.php`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a31983e1888324b5a0aefc84e5840d