### PR TITLE
Add financial dashboard for solar management plugin

### DIFF
--- a/includes/jtsm-dashboard.php
+++ b/includes/jtsm-dashboard.php
@@ -1,0 +1,85 @@
+<?php
+
+class JTSM_Solar_Management_Dashboard {
+
+    private static $instance = null;
+
+    public static function instance() {
+        if ( self::$instance === null ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Render dashboard page with totals and profit information.
+     */
+    public function jtsm_render_dashboard_page() {
+        global $wpdb;
+
+        $clients_table  = $wpdb->prefix . 'jtsm_clients';
+        $payments_table = $wpdb->prefix . 'jtsm_payments';
+
+        $total_seller_amount = $wpdb->get_var(
+            "SELECT SUM(p.amount) FROM $payments_table p JOIN $clients_table c ON p.client_id = c.id WHERE c.user_type = 'seller'"
+        );
+
+        $total_expender_amount = $wpdb->get_var(
+            "SELECT SUM(p.amount) FROM $payments_table p JOIN $clients_table c ON p.client_id = c.id WHERE c.user_type = 'expender'"
+        );
+
+        $total_consumer_amount = $wpdb->get_var(
+            "SELECT SUM(p.amount) FROM $payments_table p JOIN $clients_table c ON p.client_id = c.id WHERE c.user_type = 'consumer'"
+        );
+
+        $total_proposal_amount = $wpdb->get_var("SELECT SUM(proposal_amount) FROM $clients_table");
+
+        $total_profit = floatval( $total_consumer_amount ) - ( floatval( $total_seller_amount ) + floatval( $total_expender_amount ) );
+        $total_remaining = floatval( $total_proposal_amount ) - floatval( $total_consumer_amount );
+
+        ?>
+        <div class="wrap bg-gray-100 p-6">
+            <h1 class="text-2xl font-semibold text-gray-800 mb-4"><?php _e('Dashboard', 'jtsm'); ?></h1>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div class="bg-white p-4 rounded-lg shadow-md flex items-center justify-center">
+                    <div class="text-center">
+                        <p class="text-sm font-medium text-gray-500 uppercase"><?php _e('Total Seller Amount', 'jtsm'); ?></p>
+                        <p class="mt-1 text-3xl font-semibold text-gray-900"><?php echo number_format( floatval( $total_seller_amount ), 2 ); ?></p>
+                    </div>
+                </div>
+                <div class="bg-white p-4 rounded-lg shadow-md flex items-center justify-center">
+                    <div class="text-center">
+                        <p class="text-sm font-medium text-gray-500 uppercase"><?php _e('Total Expender Amount', 'jtsm'); ?></p>
+                        <p class="mt-1 text-3xl font-semibold text-gray-900"><?php echo number_format( floatval( $total_expender_amount ), 2 ); ?></p>
+                    </div>
+                </div>
+                <div class="bg-white p-4 rounded-lg shadow-md flex items-center justify-center">
+                    <div class="text-center">
+                        <p class="text-sm font-medium text-gray-500 uppercase"><?php _e('Total Consumer Amount', 'jtsm'); ?></p>
+                        <p class="mt-1 text-3xl font-semibold text-gray-900"><?php echo number_format( floatval( $total_consumer_amount ), 2 ); ?></p>
+                    </div>
+                </div>
+                <div class="bg-white p-4 rounded-lg shadow-md flex items-center justify-center">
+                    <div class="text-center">
+                        <p class="text-sm font-medium text-gray-500 uppercase"><?php _e('Total Proposal Amount', 'jtsm'); ?></p>
+                        <p class="mt-1 text-3xl font-semibold text-gray-900"><?php echo number_format( floatval( $total_proposal_amount ), 2 ); ?></p>
+                    </div>
+                </div>
+                <div class="bg-white p-4 rounded-lg shadow-md flex items-center justify-center">
+                    <div class="text-center">
+                        <p class="text-sm font-medium text-gray-500 uppercase"><?php _e('Total Profit', 'jtsm'); ?></p>
+                        <p class="mt-1 text-3xl font-semibold text-gray-900"><?php echo number_format( $total_profit, 2 ); ?></p>
+                    </div>
+                </div>
+                <div class="bg-white p-4 rounded-lg shadow-md flex items-center justify-center">
+                    <div class="text-center">
+                        <p class="text-sm font-medium text-gray-500 uppercase"><?php _e('Total Consumer Paid Remaining', 'jtsm'); ?></p>
+                        <p class="mt-1 text-3xl font-semibold text-gray-900"><?php echo number_format( $total_remaining, 2 ); ?></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+}
+

--- a/includes/jtsm-setup.php
+++ b/includes/jtsm-setup.php
@@ -120,6 +120,7 @@ final class JTSM_Solar_Management_Setup {
      */
     public function jtsm_admin_menu() {
         add_menu_page('Solar Management', 'Solar Management', 'manage_options', 'jtsm-main-menu', [ JTSM_Solar_Management_List_View::instance(), 'jtsm_render_client_list_page' ], 'dashicons-solar-panel', 20);
+       add_submenu_page('jtsm-main-menu', 'Dashboard', 'Dashboard', 'manage_options', 'jtsm-dashboard', [ JTSM_Solar_Management_Dashboard::instance(), 'jtsm_render_dashboard_page' ]);
        add_submenu_page('jtsm-main-menu', 'All Clients', 'All Clients', 'manage_options', 'jtsm-main-menu',  [JTSM_Solar_Management_List_View::instance(),'jtsm_render_client_list_page' ]);
        add_submenu_page('jtsm-main-menu', 'Add New Client', 'Add New Client', 'manage_options', 'jtsm-add-client',   [JTSM_Solar_Management_CRUD::instance(),'jtsm_render_add_client_page' ]);
        add_submenu_page('jtsm-main-menu', 'All Payments', 'All Payments', 'manage_options', 'jtsm-all-payments',  [JTSM_Solar_Management_List_View::instance(),'jtsm_render_payment_list_page' ]);

--- a/justech-solar-management.php
+++ b/justech-solar-management.php
@@ -29,6 +29,7 @@ define( 'JTSM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 require_once JTSM_PLUGIN_DIR . 'includes/jtsm-crud.php';
 require_once JTSM_PLUGIN_DIR . 'includes/jtsm-list-view.php';
 require_once JTSM_PLUGIN_DIR . 'includes/view-client-detail.php';
+require_once JTSM_PLUGIN_DIR . 'includes/jtsm-dashboard.php';
 
 require_once JTSM_PLUGIN_DIR . 'includes/jtsm-setup.php';
 


### PR DESCRIPTION
## Summary
- add dashboard page displaying seller, expender, consumer and proposal totals
- calculate profit and remaining consumer balance
- register dashboard in admin menu and load new class

## Testing
- `php -l justech-solar-management.php`
- `php -l includes/jtsm-setup.php`
- `php -l includes/jtsm-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68a850040df8832491e3b89a21067911